### PR TITLE
Refactor fluid handling system

### DIFF
--- a/src/main/java/xueluoanping/fluiddrawerslegacy/api/drawer/betterFluidManager.java
+++ b/src/main/java/xueluoanping/fluiddrawerslegacy/api/drawer/betterFluidManager.java
@@ -1,25 +1,19 @@
 package xueluoanping.fluiddrawerslegacy.api.drawer;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
-import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import xueluoanping.fluiddrawerslegacy.FluidDrawersLegacyMod;
 import xueluoanping.fluiddrawerslegacy.ModConstants;
 import xueluoanping.fluiddrawerslegacy.block.blockentity.BlockEntityFluidDrawer;
 
 import javax.annotation.Nonnull;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static xueluoanping.fluiddrawerslegacy.ModConstants.DRAWER_GROUP_CAPABILITY;
 
 public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements IFluidHandler {
-    private List<FluidStack> fluidRecord = new ArrayList<>();
-    private FluidStack fluid = FluidStack.EMPTY;
 
     private final T tile;
 
@@ -31,54 +25,27 @@ public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements
     }
 
 
-    public void setFluid(FluidStack loadFluidStackFromNBT) {
-        this.fluid = loadFluidStackFromNBT;
-    }
-
-    public CompoundTag writeToNBT(CompoundTag compoundTag) {
-        return this.fluid.writeToNBT(compoundTag);
-    }
-
-
-    public int getDistance(BlockPos pos1, BlockPos pos2) {
-        return Math.abs(pos1.getX() - pos2.getX()) + Math.abs(pos1.getY() - pos2.getY()) + Math.abs(pos1.getZ() - pos2.getZ());
-    }
-
-
     public List<BlockEntityFluidDrawer.FluidDrawerData> getFluidDrawerDataList() {
         try {
-
-            long startTime = System.currentTimeMillis();
-            List<BlockEntityFluidDrawer.FluidDrawerData> listNew = new ArrayList<>();
-            List<DrawerDistanceBook> listW = new ArrayList<>();
-            // FluidDrawersLegacyMod.logger(tile.getCapability(DRAWER_GROUP_CAPABILITY, null).resolve().isPresent());
             IDrawerGroup handler = DRAWER_GROUP_CAPABILITY.getCapability(tile);
             if (handler != null) {
-                // FluidDrawersLegacyMod.logger(tile.getCapability(DRAWER_GROUP_CAPABILITY, null).resolve().get().getDrawerCount()+"");
                 int size = handler.getDrawerCount();
-                for (int i = 0; i < size; i++) {
+                if (size <= 0)
+                    return List.of();
 
+                List<BlockEntityFluidDrawer.FluidDrawerData> listNew = new ArrayList<>(size);
+                for (int i = 0; i < size; i++) {
                     if (handler.getDrawer(i) instanceof BlockEntityFluidDrawer.FluidDrawerData fluidDrawerData) {
-                        // listNew.add(fluidDrawerData);
-                        int d = getDistance(tile.getBlockPos(), fluidDrawerData.getDrawerPos());
-                        // dList.add(d);
-                        listW.add(new DrawerDistanceBook(fluidDrawerData, d));
+                        listNew.add(fluidDrawerData);
                     }
                 }
-                Collections.sort(listW);
-                listNew = listW.stream().map(DrawerDistanceBook::fluidDrawerData).toList();
-
-                long endTime = System.currentTimeMillis();
-                long duration = endTime - startTime;
-                // FluidDrawersLegacyMod.logger("Cost: " + duration + "Millis");
-
                 return listNew;
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            FluidDrawersLegacyMod.LOGGER.error("Failed to gather fluid drawers for manager at {}", tile.getBlockPos(), e);
         }
 
-        return new ArrayList<>();
+        return List.of();
     }
 
     // Add NBT mechanism to allow judgment based on NBT, using the isFluidEqual method (Jade is not currently supported there)
@@ -86,117 +53,50 @@ public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements
 
     public List<FluidHolder> getFluidMap(List<BlockEntityFluidDrawer.FluidDrawerData> listNew) {
 
-        Map<FluidStack, List<Integer>> fluidMap = new LinkedHashMap<>();
-        long startTime = System.currentTimeMillis();
-        listNew.forEach(
-                (ele) -> {
-                    FluidStack fluidStack = ele.getTank().getFluid();
+        Map<FluidStack, Long> fluidMap = new LinkedHashMap<>();
 
-                    int capacity = ele.getMaxTankCapacity();
-                    List<Integer> integerList = new ArrayList<>();
-                    // indeed we not need to think about the fill because that's different
-                    // Todo: add empty Lock
-                    boolean isEmptyLockWithFluid = ele.isLock() && fluidStack.isEmpty() && !ele.getTank().getCacheFluid().isEmpty();
-                    boolean notEmpty = fluidStack.getAmount() > 0 && fluidStack != FluidStack.EMPTY;
-                    if (isEmptyLockWithFluid) {
-                        fluidStack = ele.getTank().getCacheFluid();
-                        fluidStack.setAmount(0);
-                    }
+        listNew.forEach(ele -> {
+            FluidStack fluidStack = ele.getTank().getFluid();
 
-                    // if (isEmptyLockWithFluid||notEmpty)
-                    {
-                        FluidStack fluidStackKey = fluidStack.copy();
-                        // not 0, empty
-                        if (notEmpty && !isEmptyLockWithFluid)
-                            fluidStackKey.setAmount(1);
-                        if (!notEmpty && !isEmptyLockWithFluid)
-                            fluidStackKey = FluidStack.EMPTY;
+            int capacity = ele.getMaxTankCapacity();
+            boolean isEmptyLockWithFluid = ele.isLock() && fluidStack.isEmpty() && !ele.getTank().getCacheFluid().isEmpty();
 
-                        if (fluidMap.containsKey(fluidStackKey)) {
-                            integerList = fluidMap.get(fluidStackKey);
-                            integerList.set(0, integerList.get(0) + fluidStack.getAmount());
-                            integerList.set(1, integerList.get(1) + capacity);
-                            fluidMap.replace(fluidStackKey, fluidMap.get(fluidStackKey), integerList);
-                        } else {
-                            integerList.add(fluidStack.getAmount());
-                            integerList.add(capacity);
-                            fluidMap.put(fluidStackKey, integerList);
-                        }
-                    }
-                }
-        );
+            if (isEmptyLockWithFluid) {
+                fluidStack = ele.getTank().getCacheFluid();
+                fluidStack.setAmount(0);
+            } else if (fluidStack.isEmpty()) {
+                fluidStack = FluidStack.EMPTY;
+            }
 
-        fluidRecord.removeIf(a -> fluidMap.keySet().stream().noneMatch(b -> b.equals(a)));
-        fluidRecord.addAll(fluidMap.keySet());
-        fluidRecord = new ArrayList<>(fluidMap.keySet());
-        fluidRecord = fluidRecord.stream().distinct().collect(Collectors.toList());
-
-
-        // must in the last position
-        boolean removeEmptyKey = fluidRecord.removeIf(FluidStack::isEmpty);
-        if (removeEmptyKey) {
-            fluidRecord.add(FluidStack.EMPTY);
-        }
-
-
-        List<FluidHolder> fluidHolderList = new ArrayList<>();
-        fluidRecord.forEach(fluidStack -> {
-            FluidHolder holder = new FluidHolder(fluidStack, fluidMap.get(fluidStack).get(0), fluidMap.get(fluidStack).get(1));
-            // holder.fluid = fluidStack;
-            // holder.fluidAmount = fluidMap.get(fluidStack).get(0);
-            // holder.tankCapacity = fluidMap.get(fluidStack).get(1);
-            fluidHolderList.add(holder);
+            Long packed = fluidMap.get(fluidStack);
+            if (packed != null) {
+                int amount = (int) (packed >> 32) + fluidStack.getAmount();
+                int cap = packed.intValue() + capacity;
+                packed = ((long) amount << 32) | cap;
+                fluidMap.put(fluidStack, packed);
+            } else {
+                packed = ((long) fluidStack.getAmount() << 32) | capacity;
+                fluidMap.put(fluidStack, packed);
+            }
         });
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-        // FluidDrawersLegacyMod.logger("Cost: " + duration + "Millis");
+
+        List<FluidHolder> fluidHolderList = new ArrayList<>(fluidMap.size());
+        List<FluidHolder> emptyHolderList = new ArrayList<>(fluidMap.size());
+        fluidMap.forEach((fluidStack, packed) -> {
+            int amount = (int) (packed >> 32);
+            int cap = packed.intValue();
+            FluidHolder fluidHolder = new FluidHolder(fluidStack, amount, cap);
+
+            if (!fluidStack.isEmpty())
+                fluidHolderList.add(fluidHolder);
+            else
+                emptyHolderList.add(fluidHolder);
+        });
+        fluidHolderList.addAll(emptyHolderList);
+
         return fluidHolderList;
     }
 
-    // this function is used by others, so not need to lock it
-    // note: there should use cacheFluid as a standard to check if allowed fill
-    // while drain should use the fluid it has to assure no conflict problems
-    protected int fillByOrder(List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList, List<Integer> priorityList, FluidStack resource, IFluidHandler.FluidAction action, int order) {
-        if (drawerDataList.size() == 0)
-            return 0;
-        for (int i = 0; i < drawerDataList.size(); i++) {
-            // reject invalid
-            // only find valid and same order
-            if (priorityList.get(i) != order)
-                continue;
-
-            // when locked, need to check cache, or not necessary
-            FluidStack tankCacheFluid = drawerDataList.get(i).getTank().getCacheFluid();
-
-            if (drawerDataList.get(i).isLock()) {
-                if (!tankCacheFluid.isEmpty() && !tankCacheFluid.isFluidEqual(resource)) {
-                    continue;
-                }
-            }
-
-            FluidStack tankFluid = drawerDataList.get(i).getTank().getFluid();
-            if (tankFluid.isFluidEqual(resource) || tankFluid.isEmpty()) {
-                if (resource.getAmount() + drawerDataList.get(i).getTank().getFluid().getAmount()
-                        <= drawerDataList.get(i).getTank().getCapacity() ||
-                        drawerDataList.get(i).isVoid()) {
-                    if (action.execute())
-                        drawerDataList.get(i).getTank().fill(resource, IFluidHandler.FluidAction.EXECUTE);
-                    return resource.getAmount();
-                } else {
-                    // avoid can't consume once
-                    FluidStack fluidStack = resource;
-                    fluidStack.setAmount(drawerDataList.get(i).getTank().getCapacity() -
-                            drawerDataList.get(i).getTank().getFluid().getAmount());
-                    if (action.execute())
-                        drawerDataList.get(i).getTank().fill(fluidStack, IFluidHandler.FluidAction.EXECUTE);
-                    return resource.getAmount() - fluidStack.getAmount();
-                }
-            }
-
-        }
-
-        return 0;
-    }
 
     private int getFluidDrawerPriority(BlockEntityFluidDrawer.FluidDrawerData data) {
         if (data.getTank().isFull())
@@ -215,7 +115,7 @@ public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements
             } else {
                 if (data.isVoid())
                     return ModConstants.PRI_LOCKED_VOID;
-                    //  not delete else if ,or will handle anything else
+                    // not delete else if ,or will handle anything else
                 else if (data.isLock())
                     return ModConstants.PRI_LOCKED;
             }
@@ -225,44 +125,28 @@ public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements
 
     @Override
     public int fill(FluidStack resource, IFluidHandler.FluidAction action) {
-        // FluidDrawersLegacyMod.logger("" + resource.writeToNBT(new CompoundTag()), action);
-        List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
-        int result = 0;
-        int amount = resource.getAmount();
-        final int amountF = amount;
-        // if (amountF <= 0)
-        //     return 0;
-        if (amountF > 0) {
-            int i = 0;
-            //            rember to clear it
-            List<Integer> priorityList = new ArrayList<>();
-            while (i < drawerDataList.size()) {
-                priorityList.add(getFluidDrawerPriority(drawerDataList.get(i)));
-                //                FluidDrawersLegacyMod.logger("priorityList"+priorityList.get(priorityList.size()-1));
-                i++;
-            }
+        FluidStack remaining = resource.copy();
 
-            if (drawerDataList.size() == priorityList.size() && drawerDataList.size() > 0)
-                for (int j = 0; j < ModConstants.PRI_DISABLED; j++) {
-                    //
-                    //                FluidDrawersLegacyMod.logger(resource.getAmount()+"fillByOrder"+j);
-                    amount -= fillByOrder(drawerDataList, priorityList, resource, action, j);
-                    //                amount=resource.getAmount();
-                    if (amount == 0) {
-                        //  FluidDrawersLegacyMod.logger(resource.getAmount()+"break"+j);
-                        result = amountF;
-                        break;
-                    }
+        if (!resource.isEmpty()) {
+            List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
 
+            for (BlockEntityFluidDrawer.FluidDrawerData drawer: drawerDataList) {
+                if (remaining.isEmpty())
+                    break;
+
+                int priority = getFluidDrawerPriority(drawer);
+                if (priority >= 0 && priority != ModConstants.PRI_DISABLED) {
+                    FluidStack tankFluid = drawer.getTank().getFluid();
+                    if (!tankFluid.isEmpty() && !tankFluid.isFluidEqual(resource))
+                        continue;
+
+                    int filled = drawer.getTank().fill(remaining, action);
+                    remaining.shrink(filled);
                 }
-            if (amount > 0) {
-                result = amountF - amount;
             }
         }
 
-        // RebuildLock_fill = false;
-
-        return result;
+        return resource.getAmount() - remaining.getAmount();
     }
 
     @Override
@@ -272,141 +156,101 @@ public class betterFluidManager<T extends BlockEntity & IDrawerGroup> implements
     }
 
     // the following three function must be treated cautiously
-    // because I'm not sure what would happens if return null
-
+    // because I'm not sure what would happen if return null
 
     @Nonnull
     @Override
     public FluidStack getFluidInTank(int tank) {
         List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
-        FluidHolder fluidHolder = getFluidMap(drawerDataList).get(tank);
-        // FluidStack stack = drawerDataList.get(tank).getTank().getFluid().copy();
-        // long startTime=System.currentTimeMillis();
-        // // for (int i = 0; i < 10000*1; i++) {
-        // //     getFluidDrawerDataList();
-        // //     // getFluidMap(getFluidDrawerDataList());
-        // // }
-        // long endTime = System.currentTimeMillis();
-        // long duration = endTime - startTime;
-        // FluidDrawersLegacyMod.logger("Cost: " + duration + "Millis");
-
-        return new FluidStack(fluidHolder.fluid(), fluidHolder.fluidAmount());
+        List<FluidHolder> fluidHolderList = getFluidMap(drawerDataList);
+        if (fluidHolderList.size() > tank) {
+            FluidHolder holder = fluidHolderList.get(tank);
+            return new FluidStack(holder.fluid(), holder.fluidAmount());
+        } else {
+            return FluidStack.EMPTY;
+        }
     }
 
     @Override
     public int getTankCapacity(int tank) {
         List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
-        FluidHolder fluidHolder = getFluidMap(drawerDataList).get(tank);
-        // int amount = drawerDataList.get(tank).getTank().getCapacity();
-        return fluidHolder.tankCapacity();
+        List<FluidHolder> fluidHolderList = getFluidMap(drawerDataList);
+        if (fluidHolderList.size() > tank) {
+            return fluidHolderList.get(tank).tankCapacity();
+        } else {
+            return 0;
+        }
     }
 
     @Override
     public boolean isFluidValid(int tank, @Nonnull FluidStack stack) {
         List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
-        FluidHolder fluidHolder = getFluidMap(drawerDataList).get(tank);
-        // boolean result = drawerDataList.get(tank).getTank().isFluidValid(tank, stack);
-
-        return stack.isFluidEqual(fluidHolder.fluid()) && stack.getAmount() + fluidHolder.fluidAmount() <= fluidHolder.tankCapacity();
+        List<FluidHolder> fluidHolderList = getFluidMap(drawerDataList);
+        if (fluidHolderList.size() > tank) {
+            FluidHolder holder = fluidHolderList.get(tank);
+            return stack.isFluidEqual(holder.fluid()) &&
+                    stack.getAmount() + holder.fluidAmount() <= holder.tankCapacity();
+        } else {
+            return false;
+        }
     }
 
 
-    // when action.execute ,can't give out the fluidstack ,or something bad would happen
-    // note it's just a address ,so can't let others can change value directly
+    // when action.execute, can't give out the fluid stack, or something bad would happen
+    // note it's just an address, so can't let others can change value directly
     @Nonnull
     @Override
     public FluidStack drain(FluidStack resource, IFluidHandler.FluidAction action) {
-        //            FluidDrawersLegacyMod.logger("Drainresource" + resource.writeToNBT(new CompoundNBT()));
-        // RebuildLock_drain0 = true;
-        // FluidDrawersLegacyMod.logger(action, resource.writeToNBT(new CompoundTag()));
+        if (resource.isEmpty()) {
+            return FluidStack.EMPTY;
+        }
 
         List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
 
-        // FluidDrawersLegacyMod.logger(getFluidMap(drawerDataList));
-        FluidStack result = FluidStack.EMPTY;
-        FluidStack resourceCopy = resource.copy();
-        // if (action.execute()) return result;
-        if (!resourceCopy.isEmpty() && resourceCopy.getAmount() > 0) {
-            for (int i = 0; i < drawerDataList.size(); i++) {
-                if (resourceCopy.getAmount() <= 0) break;
-                int drawerFluidAmount = drawerDataList.get(i).getTank().getFluid().getAmount();
-                if (drawerDataList.get(i).getTank().getFluid().isEmpty())
-                    continue;
-                if (drawerDataList.get(i).getTank().getFluid().isFluidEqual(resourceCopy) && drawerFluidAmount > 0) {
-                    // FluidStack temp = new FluidStack(drawerFluid, Math.min(drawerFluidAmount, resourceCopy.getAmount()));
-                    //
-                    // // FluidStack temp =
-                    // if (action.execute())
-                    FluidStack temp = drawerDataList.get(i).getTank().drain(resourceCopy, action);
-                    if (temp.getAmount() > 0) {
-                        if (result == FluidStack.EMPTY)
-                            result = temp;
-                        else result.grow(temp.getAmount());
-                        resourceCopy.shrink(temp.getAmount());
-                        // break;
-                    }
+        int toDrain = resource.getAmount();
+        int drained = 0;
+
+        for (int i = 0; i < drawerDataList.size() && toDrain > 0; i++) {
+            BlockEntityFluidDrawer.betterFluidHandler handler = drawerDataList.get(i).getTank();
+
+            if (handler.getFluid().isFluidEqual(resource)) {
+                FluidStack temp = handler.drain(toDrain, action);
+                if (!temp.isEmpty()) {
+                    toDrain -= temp.getAmount();
+                    drained += temp.getAmount();
                 }
             }
         }
-        // RebuildLock_drain0 = false;
 
-        return result;
+        return new FluidStack(resource, drained);
     }
 
     @Nonnull
     @Override
     public FluidStack drain(int maxDrain, IFluidHandler.FluidAction action) {
-        //            FluidDrawersLegacyMod.LOGGER.info("Drainmmmm" + maxDrain);
-        // RebuildLock_drain = true;
-        // FluidDrawersLegacyMod.logger(action, maxDrain);
+
         List<BlockEntityFluidDrawer.FluidDrawerData> drawerDataList = getFluidDrawerDataList();
-        List<FluidHolder> fluidHolder = getFluidMap(drawerDataList);
 
         FluidStack result = FluidStack.EMPTY;
-        // FluidStack fluidType = FluidStack.EMPTY;
-        // Strange , 0<0 ,but for will ingroe it.
-        if (maxDrain > 0 && drawerDataList.size() > 0 && fluidHolder.size() > 0) {
+        for (int i = 0; i < drawerDataList.size() && maxDrain > 0; i++) {
+            BlockEntityFluidDrawer.betterFluidHandler handler = drawerDataList.get(i).getTank();
 
-            // tile.getLevel().dimensionTypeId
-            if (tile.getLevel() instanceof ServerLevel) {
-                // FluidDrawerControllerSave fluidDrawerControllerSave = FluidDrawerControllerSave.get(tile.getLevel());
-                // this.fluid = fluidDrawerControllerSave.get(tile.getBlockPos());
-                if (this.fluid.isEmpty() || !fluidRecord.contains(this.fluid))
-                    this.fluid = fluidHolder.get(0).fluid();
-                // fluidDrawerControllerSave.update(tile.getBlockPos(), this.fluid);
-            }
-            for (int i = 0; i < drawerDataList.size(); i++) {
-                if (maxDrain <= 0) break;
-                if (drawerDataList.get(i).getTank().getFluid().getFluid() == Fluids.EMPTY)
-                    continue;
-                if (drawerDataList.get(i).getTank().getFluid().getAmount() > 0) {
-                    if (!result.isEmpty() && !result.isFluidEqual(drawerDataList.get(i).getTank().getFluid()))
-                        continue;
+            if (handler.getFluid().isEmpty())
+                continue;
+            if (!result.isEmpty() && !handler.getFluid().isFluidEqual(result))
+                continue;
 
+            FluidStack temp = handler.drain(maxDrain, action);
 
-                    // FluidStack temp = new FluidStack(!result.isEmpty() ? result : drawerDataList.get(i).getTank().getFluid(), maxDrain);
-                    FluidStack temp = new FluidStack(!result.isEmpty() ? result : this.fluid, maxDrain);
-                    temp = drawerDataList.get(i).getTank().drain(temp, action);
-                    if (temp.getAmount() > 0) {
-                        if (result == FluidStack.EMPTY)
-                            result = temp;
-                        else result.grow(temp.getAmount());
-                        maxDrain -= temp.getAmount();
-                    }
-                }
-
+            if (temp.getAmount() > 0) {
+                if (result.isEmpty())
+                    result = temp;
+                else result.grow(temp.getAmount());
+                maxDrain -= temp.getAmount();
             }
         }
 
-        // if (result.getAmount() <= 0) {
-        //     // RebuildLock_drain = false;
-        //     result= FluidStack.EMPTY;
-        // }
-        // RebuildLock_drain = false;
-
         return result;
     }
-
-
 }
 

--- a/src/main/java/xueluoanping/fluiddrawerslegacy/block/blockentity/BlockEntityFluidDrawer.java
+++ b/src/main/java/xueluoanping/fluiddrawerslegacy/block/blockentity/BlockEntityFluidDrawer.java
@@ -45,6 +45,7 @@ import xueluoanping.fluiddrawerslegacy.util.RegisterFinderUtil;
 import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
+@SuppressWarnings("unused")
 public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworked, IFluidDrawerGroup {
 
     private final BasicDrawerAttributes drawerAttributes = new DrawerAttributes();
@@ -52,23 +53,24 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
     private final FluidGroupData fluidGroupData;
     private final UpgradeData upgradeData = new BlockEntityFluidDrawer.DrawerUpgradeData();
     private final LazyOptional<?> capabilityGroup = LazyOptional.of(this::getGroup);
-    //    public static int Capacity = 32000;
+
     private final ControllerData controllerData = new ControllerData();
 
     public FluidAnimation fluidAnimation = new FluidAnimation();
 
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public BlockEntityFluidDrawer(int slotCount, BlockPos pos, BlockState state) {
-        super(ModContents.DRBlockEntities.getEntries().stream().filter(blockEntityTypeRegistryObject -> blockEntityTypeRegistryObject.getId().equals(RegisterFinderUtil.getBlockKey(state.getBlock()))).findFirst().get().get(), pos, state);
+        super(ModContents.DRBlockEntities.getEntries().stream().filter(
+                blockEntityTypeRegistryObject -> RegisterFinderUtil.getBlockKey(state.getBlock()).equals(blockEntityTypeRegistryObject.getId())
+        ).findFirst().get().get(), pos, state);
         this.fluidGroupData = new FluidGroupData(slotCount, this);
 
-        // this.fluidGroupData.setCapabilityProvider(this);
         this.injectPortableData(fluidGroupData);
 
         this.upgradeData.setDrawerAttributes(this.drawerAttributes);
         this.injectPortableData(this.upgradeData);
         injectPortableData(controllerData);
-        //        FluidDrawersLegacyMod.logger("create tile");
     }
 
     private void checkBoundController() {
@@ -82,7 +84,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
         }
 
         if (remote != null && remote.getItem() instanceof ItemUpgradeRemote itemRemote) {
-            BlockEntityController upgradeController = itemRemote.getBoundController(remote, level);
+            BlockEntityController upgradeController = ItemUpgradeRemote.getBoundController(remote, level);
             if (controller != null && controller != upgradeController)
                 controller.invalidateRemoteNode(this);
 
@@ -125,18 +127,13 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
     }
 
 
-    //    @Override
     public IDrawerGroup getGroup() {
         return this.fluidGroupData;
     }
 
-    //    @Override
     protected void onAttributeChanged() {
-        //        super.onAttributeChanged();
         this.requestModelDataUpdate();
-        // fluidGroupData.syncAttributes();
     }
-
 
     public void inventoryChanged() {
         super.setChanged();
@@ -152,7 +149,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
 
     @NotNull
     @Override
-    public IFluidDrawer getDrawer(int i) {
+    public FluidDrawerData getDrawer(int i) {
         return fluidGroupData.getDrawer(i);
     }
 
@@ -199,7 +196,6 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             if (attrs != null) {
                 this.drawerAttributes.setItemLocked(LockAttribute.LOCK_EMPTY, attrs.contains(LockAttribute.LOCK_EMPTY));
                 this.drawerAttributes.setItemLocked(LockAttribute.LOCK_POPULATED, attrs.contains(LockAttribute.LOCK_POPULATED));
-                //                    FluidDrawersLegacyMod.logger( attrs.contains(LockAttribute.LOCK_POPULATED)+""+ attrs.contains(LockAttribute.LOCK_EMPTY));
             }
         } else {
             this.drawerAttributes.setItemLocked(LockAttribute.LOCK_EMPTY, false);
@@ -216,19 +212,10 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
 
     }
 
-    //    @Override
+    // @Override
     public IDrawerAttributes getDrawerAttributes() {
         return this.drawerAttributes;
     }
-
-    // protected void syncClientCount(int slot, int count) {
-    //     if (this.getLevel() == null || !this.getLevel().isClientSide) {
-    //         PacketDistributor.TargetPoint point = new PacketDistributor.TargetPoint((double) this.getBlockPos().getX(), (double) this.getBlockPos().getY(), (double) this.getBlockPos().getZ(), 500.0D, this.getLevel().dimension());
-    //         CountUpdateMessageHandler.send(PacketDistributor.NEAR.with(() -> {
-    //             return point;
-    //         }), new CountUpdateMessage(this.getBlockPos(), slot, count));
-    //     }
-    // }
 
     public betterFluidManager<BlockEntityFluidDrawer> getTank() {
         return this.fluidGroupData.tank;
@@ -278,9 +265,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
                     tankCapacity /= size;
             }
             var up = new UpgradeData(7);
-            up.setDrawerAttributes(new IDrawerAttributesModifiable() {
-            });
-            // up.setDrawerAttributes(new BasicDrawerAttributes());
+            up.setDrawerAttributes(new IDrawerAttributesModifiable() {});
             up.read(tag);
             int mul = up.getStorageMultiplier();
             tankCapacity *= mul;
@@ -295,18 +280,17 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
     }
 
 
-    //    @Override
+
     public int getRedstoneLevel() {
-        //        FluidDrawersLegacyMod.logger(getLevel().toString()+this.isRedstone());
         return (int) (((float) getCapacityUsed() / (float) getCapacityEffective()) * 15);
     }
 
-    //    @Override
+
     public boolean isRedstone() {
         return upgrades().getRedstoneType() != null;
     }
 
-    //    @Override
+
     public UpgradeData upgrades() {
         return this.upgradeData;
     }
@@ -329,12 +313,12 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             for (int i = 0; i < slotCount; ++i) {
                 this.slots[i] = this.createDrawer(i);
             }
-            tank = createFuildHandler(blockEntityFluidDrawer);
+            tank = createFluidHandler(blockEntityFluidDrawer);
             tankHandler = LazyOptional.of(() -> tank);
 
         }
 
-        private betterFluidManager<BlockEntityFluidDrawer> createFuildHandler(BlockEntityFluidDrawer blockEntityFluidDrawer) {
+        private betterFluidManager<BlockEntityFluidDrawer> createFluidHandler(BlockEntityFluidDrawer blockEntityFluidDrawer) {
             return new betterFluidManager<>(blockEntityFluidDrawer);
         }
 
@@ -349,7 +333,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
         }
 
         @Override
-        public @NotNull IFluidDrawer getDrawer(int i) {
+        public @NotNull FluidDrawerData getDrawer(int i) {
             return this.slots[i];
         }
 
@@ -360,7 +344,6 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
 
         @Override
         public boolean isGroupValid() {
-            //            return TileEntityFluidDrawer.this.isGroupValid();
             return !BlockEntityFluidDrawer.this.isRemoved();
         }
 
@@ -374,35 +357,35 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
         public CompoundTag write(CompoundTag tag) {
             upgradeData.write(tag);
 
-            ListTag tanklist = new ListTag();
+            ListTag tankList = new ListTag();
             for (FluidDrawerData data : this.slots) {
-                tanklist.add(data.serializeNBT());
+                tankList.add(data.serializeNBT());
             }
-            tag.put("tanks", tanklist);
+            tag.put("tanks", tankList);
 
-            //            inventoryChanged();
-            //            If want to camouflage, pay attention to setting the capacity first, but we don't need it.
+            // inventoryChanged();
+            // If want to camouflage, pay attention to setting the capacity first, but we don't need it.
             return tag;
         }
 
 
         @Override
         public void read(CompoundTag nbt) {
-            //            if(!getLevel().isClientSide())
-            //            FluidDrawersLegacyMod.logger(getLevel().isClientSide()+"");
-            //            upgrades must first,to adjust the capacity
+            // if(!getLevel().isClientSide())
+            //     FluidDrawersLegacyMod.logger(getLevel().isClientSide()+"");
+            // upgrades must first,to adjust the capacity
             upgrades().read(nbt);
-            //            FluidDrawersLegacyMod.logger("read"+nbt.toString());
+            // FluidDrawersLegacyMod.logger("read"+nbt.toString());
 
             if (nbt.contains("tank")) {
                 this.slots[0].deserializeNBT(nbt.getCompound("tank"));
             } else if (nbt.contains("tanks")) {
-                var tanklist = nbt.getList("tanks", ListTag.TAG_COMPOUND);
-                for (int i = 0; i < tanklist.size(); i++) {
-                    this.slots[i].deserializeNBT(tanklist.getCompound(i));
+                var tankList = nbt.getList("tanks", ListTag.TAG_COMPOUND);
+                for (int i = 0; i < tankList.size(); i++) {
+                    this.slots[i].deserializeNBT(tankList.getCompound(i));
                 }
             }
-            //            inventoryChanged();
+            // inventoryChanged();
         }
 
         public boolean idVoidUpgrade() {
@@ -413,8 +396,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
 
     // IDrawer,
     public class FluidDrawerData implements IFluidDrawer<betterFluidHandler>, INBTSerializable<CompoundTag> {
-        private int slot;
-        //        private FluidStack fluid = new FluidStack(Fluids.EMPTY, 0);
+        private final int slot;
         private final FluidGroupData group;
         private final betterFluidHandler tank;
         public FluidAnimation fluidAnimation = new FluidAnimation();
@@ -459,7 +441,6 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
         }
 
 
-        // @Override
         public int getMaxTankCapacity() {
             return getCapacityTankEffective();
         }
@@ -498,8 +479,6 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
         @Override
         public FluidStack getFluid() {
             if (upgrades().hasVendingUpgrade() && this.fluid.getFluid() != Fluids.EMPTY) {
-                //                FluidStack stack = fluid.copy();
-                //                stack.setAmount(Integer.MAX_VALUE);
                 return new FluidStack(super.getFluid(), Integer.MAX_VALUE);
             }
             return super.getFluid();
@@ -510,18 +489,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             if (this.getCapacity() != BlockEntityFluidDrawer.this.getCapacityTankEffective())
                 this.setCapacity(BlockEntityFluidDrawer.this.getCapacityTankEffective());
             CompoundTag nbt = new CompoundTag();
-            if (getCacheFluid().getRawFluid() != Fluids.EMPTY &&
-                    fluid.getFluid() != Fluids.EMPTY &&
-                    getCacheFluid().getRawFluid() != fluid.getFluid()) {
-                setCacheFluid(getFluid());
-            }
-            if (getCacheFluid().getRawFluid() == Fluids.EMPTY &&
-                    getFluid().getAmount() > 0) {
-                setCacheFluid(getFluid());
 
-            }
-
-            // nbt.putString("cache", cacheFluid.getFluidType().toString());
             nbt.put("cache", cacheFluid.writeToNBT(new CompoundTag()));
             return writeToNBT(nbt);
         }
@@ -536,7 +504,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             readFromNBT(tank);
         }
 
-        //        need to override ,or not sync
+        // need to override ,or not sync
         @Override
         protected void onContentsChanged() {
 
@@ -555,18 +523,8 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             if (upgrades().hasVendingUpgrade())
                 return 0;
             if (getDrawerAttributes().isItemLocked(LockAttribute.LOCK_EMPTY)) {
-                if (getCacheFluid().getRawFluid() != Fluids.EMPTY
-                        && !getCacheFluid().isFluidEqual(resource)) {
+                if (getCacheFluid().getRawFluid() == Fluids.EMPTY || !getCacheFluid().isFluidEqual(resource)) {
                     return 0;
-                }
-                if (getCacheFluid().getRawFluid() == Fluids.EMPTY) {
-                    if (resource.getAmount() > 0) {
-                        if (action.execute())
-                            setCacheFluid(resource);
-                        return super.fill(resource, action);
-                    } else
-                        return 0;
-
                 }
             }
             if ((this.getCapacity() - fluid.getAmount() - resource.getAmount()) < 0
@@ -579,6 +537,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
                 }
                 if (fluid.isEmpty()) {
                     fluid = new FluidStack(resource, Math.min(capacity, resource.getAmount()));
+                    setCacheFluid(resource);
                     onContentsChanged();
                     return fluid.getAmount();
                 }
@@ -588,15 +547,21 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
                 fluid.setAmount(capacity);
                 onContentsChanged();
                 return resource.getAmount();
+            } else {
+                boolean wasEmpty = fluid.isEmpty();
+                int filled = super.fill(resource, action);
+                if (wasEmpty && filled > 0) {
+                    setCacheFluid(resource);
+                }
+                return filled;
             }
-            return super.fill(resource, action);
         }
 
         @Nonnull
         @Override
         public FluidStack drain(FluidStack resource, FluidAction action) {
             if (upgrades().hasVendingUpgrade())
-                return resource.getFluid() == fluid.getFluid() ?
+                return resource.isFluidEqual(fluid) ?
                         new FluidStack(fluid.getFluid(), resource.getAmount()) :
                         FluidStack.EMPTY;
             return super.drain(resource, action);
@@ -609,12 +574,10 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
                 return new FluidStack(fluid.getFluid(), maxDrain);
             return super.drain(maxDrain, action);
         }
-
-
     }
 
 
-    //    extra attributes, not very useful
+    // extra attributes, not very useful
     private class DrawerAttributes extends BasicDrawerAttributes {
         private DrawerAttributes() {
         }
@@ -638,8 +601,7 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
 
         @Override
         public boolean setItemLocked(LockAttribute attr, boolean isLocked) {
-            boolean result = super.setItemLocked(attr, isLocked);
-            return result;
+            return super.setItemLocked(attr, isLocked);
         }
     }
 
@@ -677,17 +639,17 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
                 ItemStack upgrade = this.getUpgrade(slot);
                 if (upgrade.getItem() instanceof ItemUpgradeStorage) {
                     int storageLevel = ((ItemUpgradeStorage) upgrade.getItem()).level.getLevel();
-                    int storageMult = ModCommonConfig.INSTANCE.UPGRADES.getLevelMult(storageLevel);
-                    int effectiveStorageMult = BlockEntityFluidDrawer.this.upgrades().getStorageMultiplier();
-                    //                    单个物品特殊处理，
-                    if (effectiveStorageMult == storageMult) {
-                        --storageMult;
+                    int storageMulti = ModCommonConfig.INSTANCE.UPGRADES.getLevelMult(storageLevel);
+                    int effectiveStorageMulti = BlockEntityFluidDrawer.this.upgrades().getStorageMultiplier();
+                    // 单个物品特殊处理
+                    if (effectiveStorageMulti == storageMulti) {
+                        --storageMulti;
                     }
 
                     for (int i = 0; i < getDrawerCount(); i++) {
                         int amount = getDrawer(i).getTank().getFluidAmount();
                         int standardCapacity = getCapacityTankStandard();
-                        int afterCapacity = standardCapacity * (effectiveStorageMult - storageMult);
+                        int afterCapacity = standardCapacity * (effectiveStorageMulti - storageMulti);
                         if (afterCapacity < amount)
                             return false;
                     }
@@ -708,16 +670,5 @@ public class BlockEntityFluidDrawer extends BaseBlockEntity implements INetworke
             }
 
         }
-
-        //        private boolean stackCapacityCheck(int stackCapacity) {
-        //            return false;
-        //        }
-        //
-        //        @Override
-        //        public int getStorageMultiplier() {
-        ////            if(hasOneStackUpgrade())return super.getStorageMultiplier()/32;
-        //            return super.getStorageMultiplier();
-        //        }
-
     }
 }

--- a/src/main/java/xueluoanping/fluiddrawerslegacy/capability/CapabilityProvider_FluidDrawerController.java
+++ b/src/main/java/xueluoanping/fluiddrawerslegacy/capability/CapabilityProvider_FluidDrawerController.java
@@ -3,14 +3,10 @@ package xueluoanping.fluiddrawerslegacy.capability;
 import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fluids.FluidStack;
-// import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.common.Mod;
 import xueluoanping.fluiddrawerslegacy.api.drawer.betterFluidManager;
 
@@ -18,41 +14,26 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
-public class CapabilityProvider_FluidDrawerController implements ICapabilityProvider, INBTSerializable<CompoundTag> {
+public class CapabilityProvider_FluidDrawerController implements ICapabilityProvider {
 
     public final betterFluidManager<BlockEntityController> tank;
     private final LazyOptional<betterFluidManager<BlockEntityController>> tankHandler;
     public static BlockPos tilePos = null;
     final BlockEntityController tile;
-    // private List<TileEntityFluidDrawer.StandardDrawerData> drawerDataList = new ArrayList<>();
 
     public CapabilityProvider_FluidDrawerController(final BlockEntityController tile) {
         this.tile = tile;
-        tank = createFuildHandler();
+        tank = createFluidHandler();
         tankHandler = LazyOptional.of(() -> tank);
         tilePos = tile.getBlockPos();
         FluidDrawerControllerData fluidDrawerControllerData = new FluidDrawerControllerData();
         fluidDrawerControllerData.setCapabilityProvider(this);
         this.tile.injectData(fluidDrawerControllerData);
-        // tank.setFluid(FluidDrawerControllerSave.fluidDrawerControllerSave.);
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        return tank.writeToNBT(new CompoundTag());
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        // FluidDrawersLegacyMod.logger(22554, nbt);
-        // if (nbt.contains("Fluid"))
-        tank.setFluid(FluidStack.loadFluidStackFromNBT(nbt));
     }
 
     public void invalidate() {
         tankHandler.invalidate();
     }
-
 
 
     @Nonnull
@@ -65,154 +46,7 @@ public class CapabilityProvider_FluidDrawerController implements ICapabilityProv
     }
 
 
-    private betterFluidManager<BlockEntityController> createFuildHandler() {
+    private betterFluidManager<BlockEntityController> createFluidHandler() {
         return new betterFluidManager<>(tile);
     }
-
-
-
-    //    private static class FluidSlotRecord implements Comparable<FluidSlotRecord> {
-    //
-    //        private static final IDrawerAttributes EMPTY_ATTRS = new EmptyDrawerAttributes();
-    //        private static final int PRI_LOCKED = 0;
-    //        private static final int PRI_LOCKED_VOID = 1;
-    //        private static final int PRI_NORMAL = 2;
-    //        private static final int PRI_VOID = 3;
-    //        private static final int PRI_EMPTY = 4;
-    //        private static final int PRI_LOCKED_EMPTY = 5;
-    //
-    //        private final FluidDrawerGroup group;
-    //        private final int slot;
-    //        private final BlockPos pos;
-    //        private final int priority;
-    //
-    //        int index;
-    //
-    //        FluidSlotRecord(FluidDrawerGroup group, int slot, BlockPos pos) {
-    //            this.group = group;
-    //            this.slot = slot;
-    //            this.pos = pos;
-    //            this.priority = computePriority();
-    //        }
-    //
-    //        int computePriority() {
-    //            FluidDrawer drawer = group.getFluidDrawer(slot);
-    //            return 0;
-    ////            IDrawerAttributes attrs = group.hasCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null)
-    ////  ? Objects.requireNonNull(group.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null))
-    ////  : EMPTY_ATTRS;
-    ////            if (drawer.isEmpty()) {
-    ////                return attrs.isItemLocked(LockAttribute.LOCK_EMPTY) ? PRI_LOCKED_EMPTY : PRI_EMPTY;
-    ////            } else if (attrs.isVoid()) {
-    ////                return attrs.isItemLocked(LockAttribute.LOCK_POPULATED) ? PRI_LOCKED_VOID : PRI_VOID;
-    ////            } else {
-    ////                return attrs.isItemLocked(LockAttribute.LOCK_POPULATED) ? PRI_LOCKED : PRI_NORMAL;
-    ////            }
-    //        }
-    //
-    //        FluidDrawer getDrawer() {
-    //            return group.getFluidDrawer(slot);
-    //        }
-    //
-    //        boolean isDrawerValid() {
-    //            return group.isFluidDrawerGroupValid();
-    //        }
-    //
-    //        @Override
-    //        public int compareTo(FluidSlotRecord other) {
-    //            int diff = priority - other.priority;
-    //            return diff != 0 ? diff : pos.compareTo(other.pos);
-    //        }
-    //
-    //    }
-
-    // @SubscribeEvent
-    // public static void StopForSave(LevelEvent.Unload event) {
-    //     if (timerList.size() == 0)
-    //         return;
-    //     for (int i = 0; i < timerList.size(); i++) {
-    //         timerList.get(i).cancel();
-    //         FluidDrawersLegacyMod.logger("TRY CLOSE" + i);
-    //     }
-    //     timerList.clear();
-    // }
-
-
-    // use to find all nodes
-    // public void searchNode(Level world, BlockPos originPos, BlockPos basePos) {
-    //
-    //     if (!world.hasChunk(originPos.getX() >> 4, originPos.getZ() >> 4))
-    //         return;
-    //     // above
-    //     BlockPos p1 = originPos.above();
-    //     if (withinRange(p1, basePos))
-    //         if (testBlock(world.getBlockState(p1).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p1) + p1.toString() +
-    //                     (Math.abs(p1.getY() - basePos.getY()) + Math.abs(p1.getY() - basePos.getY()) + Math.abs(p1.getZ() - basePos.getZ())));
-    //             searchNode(world, p1, basePos);
-    //         }
-    //     //        east
-    //     BlockPos p2 = originPos.east();
-    //     if (withinRange(p2, basePos)) {
-    //         if (testBlock(world.getBlockState(p2).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p2).toString());
-    //
-    //             searchNode(world, p2, basePos);
-    //         }
-    //     }
-    //     //        south
-    //     BlockPos p3 = originPos.south();
-    //     if (withinRange(p3, basePos)) {
-    //         if (testBlock(world.getBlockState(p3).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p3).toString());
-    //             searchNode(world, p3, basePos);
-    //         }
-    //     }
-    //     //        west
-    //     BlockPos p4 = originPos.west();
-    //     if (withinRange(p4, basePos)) {
-    //         if (testBlock(world.getBlockState(p4).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p4).toString());
-    //             searchNode(world, p4, basePos);
-    //         }
-    //     }
-    //     //        north
-    //     BlockPos p5 = originPos.north();
-    //     if (withinRange(p5, basePos)) {
-    //         if (testBlock(world.getBlockState(p5).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p5).toString());
-    //             searchNode(world, p5, basePos);
-    //         }
-    //     }
-    //     //        below
-    //     BlockPos p6 = originPos.below();
-    //     if (withinRange(p6, basePos)) {
-    //         if (testBlock(world.getBlockState(p6).getBlock())) {
-    //             FluidDrawersLegacyMod.logger(world.getBlockState(p6).toString());
-    //             searchNode(world, p6, basePos);
-    //         }
-    //     }
-    // }
-    //
-    // private boolean testBlock(Block block) {
-    //     if (block instanceof INetworked)
-    //         return true;
-    //     return false;
-    // }
-
-    // private boolean withinRange(BlockPos checkPos, BlockPos basePos) {
-    //     if (posStack.search(checkPos) != -1)
-    //         return false;
-    //     posStack.push(checkPos);
-    //     if (checkPos.getY() > 256 || checkPos.getY() < 0)
-    //         return false;
-    //     if (Math.max(Math.abs(checkPos.getY() - basePos.getY()),
-    //             Math.max(
-    //                     Math.abs(checkPos.getY() - basePos.getY())
-    //                     , Math.abs(checkPos.getZ() - basePos.getZ())))
-    //             < (CommonConfig.GENERAL.controllerRange.get() / 2 + 1))
-    //         return true;
-    //     return false;
-    // }
-
 }

--- a/src/main/java/xueluoanping/fluiddrawerslegacy/capability/FluidDrawerControllerData.java
+++ b/src/main/java/xueluoanping/fluiddrawerslegacy/capability/FluidDrawerControllerData.java
@@ -1,40 +1,26 @@
 package xueluoanping.fluiddrawerslegacy.capability;
 
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.BlockEntityDataShim;
-import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.StandardDrawerGroup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.common.util.INBTSerializable;
-import net.minecraftforge.fluids.FluidStack;
 import xueluoanping.fluiddrawerslegacy.FluidDrawersLegacyMod;
 
-import java.lang.ref.WeakReference;
 
 public class FluidDrawerControllerData extends BlockEntityDataShim {
     ICapabilityProvider capProvider;
 
-    private static final String KEY="FluidDrainCache";
-    // WeakReference
     public void setCapabilityProvider(ICapabilityProvider capProvider) {
         this.capProvider = capProvider;
     }
 
     @Override
     public void read(CompoundTag compoundTag) {
-        FluidDrawersLegacyMod.logger("Load",KEY, compoundTag);
-        if (capProvider instanceof CapabilityProvider_FluidDrawerController capabilityProviderFluidDrawerController) {
-            if (compoundTag.contains(KEY))
-                capabilityProviderFluidDrawerController.deserializeNBT(compoundTag.getCompound(KEY));
-        }
+        FluidDrawersLegacyMod.logger("Load Drawer", compoundTag);
     }
 
     @Override
     public CompoundTag write(CompoundTag compoundTag) {
-        FluidDrawersLegacyMod.logger("Save",KEY, compoundTag);
-        if (capProvider instanceof CapabilityProvider_FluidDrawerController capabilityProviderFluidDrawerController) {
-            // return capabilityProviderFluidDrawerController.serializeNBT();
-            compoundTag.put(KEY, capabilityProviderFluidDrawerController.serializeNBT());
-        }
+        FluidDrawersLegacyMod.logger("Save Drawer", compoundTag);
         return compoundTag;
     }
 


### PR DESCRIPTION
### Summary

此提交重写了流体抽屉组的流体处理系统，旧的实现存在对forge流体api的多处误用、冗余代码、明显的性能问题
This PR completely refactors the fluid handling system of the Fluid Drawers. The previous implementation contained several incorrect usages of the Forge fluid API, redundant logic, and multiple performance issues.

经过重构，修复了若干处bug，并显著提高了性能
This refactor cleans up the codebase, fixes several bugs, and significantly improves performance.

### Changes

1. **整理代码**，修正少量拼写错误，移除过时的注释

2. **移除部分无效代码
- 修改对象后立即将其抛弃
- 对map键去重
- 遍历抽屉组后，再重复排序
- `fill`/`drain`方法中重复的条件判断

3. **流体逻辑修复**

重写了所有空流体和流体相等判断逻辑，因为先前的代码误用了forge的流体api

其中这个bug被修复:
> 向单格流体抽屉填充药水并锁定过滤，从管理器抽取，抽空药水后将导致崩溃

4. **为部分`ArrayList#get`操作添加边界检查**，因为某些模组可能不做检查而触发越界错误
> 例如机械动力: 柴油动力的燃料爆炸逻辑

5. **锁定行为调整**
先前抽屉保存有液体过滤信息时，再输入新的液体不会正确覆盖记录

6. **性能优化**
采用了一些激进的优化方案:
- 先前，当不要求过滤时，`drain`会记录抽取种类并在下次使用————现在永远只会抽取找到的第一个任意液体
- 移除了`fill`中的优先级机制 (例如通用的空槽优先于带有过滤的空槽，玩家往往不想要这个)
这些优化以行为改变为代价，显著改善了流体操作的性能

1. **Cleaned up the codebase**. Fixed several minor spelling mistakes. Removed outdated comments

2. **Removed meaningless operations in the codebase**, including:
- modifying objects and immediately discarding them
- unnecessary map key deduplication
- performing BFS over drawer groups and then sorting by distance
- repeated logic checks in `fill`/`drain`

3. **Fluid Logic Fixes**
All logic related to empty fluid checks and fluid equality comparisons has been rewritten, as the previous implementation used the Forge fluid API incorrectly.

One notable bug caused by this issue:

> If a single-slot fluid drawer is filled with any potion and then locked, extracting the fluid via the controller would cause a crash once the potion is fully drained.

This bug is now fixed.

4. **Added boundary checks for `ArrayList#get`**, as some mods may trigger out-of-bounds errors.
> For example, this was observed with the fuel explosion logic in Create: Diesel Generators.

5. **Locking / Filtering Fix**
Adjusted the fluid filtering logic when drawers are locked. Previously, changing the filter would not always be saved correctly.

6. **Performance Optimizations**

Several aggressive optimizations were applied:

- Removed the mechanism that recorded the last extracted fluid type when no type was present. `drain` now simply finds the first accessible fluid.

- Removed the priority-based fill logic (e.g. preferring generic empty slots over filtered empty slots, which rarely matched player expectations and introduced unnecessary overhead).

Removing these mechanisms significantly simplifies the logic and reduces the cost of fluid operations.

### Results

使用包含八种流体的抽屉组测试，结果表明流体输入/输出操作的卡顿降低了约70%
Testing with eight fluids in a drawer group showed ~70% lower CPU cost for both insertion and extraction.
提到的恶性崩溃甚至死档问题已正确修复
The mentioned crash caused by incorrect empty-fluid handling is also fully resolved.

### Compatibility / Risks

这个PR涉及的修改范围过大，有引入新bug的隐患，并且一些优化手段过于激进，尽管效果显著，但却是以行为变化为代价
This PR makes large-scale changes and may introduce new bugs.
Some optimizations are intentionally aggressive and slightly change drawer behavior, although they provide substantial performance benefits.

此外，修改仅在1.20.1Forge开发和测试。由于MC流体系统的复杂性，不能保证修改适用其他版本 (尤其是1.21 NeoForge)
欢迎反馈和额外的测试，请随意编辑此 PR
Additionally:
The changes were only developed and tested on Forge 1.20.1.
Due to the complexity of Minecraft's fluid system and the many subtle pitfalls in the API, compatibility with other versions (especially 1.21 NeoForge) cannot be guaranteed.

Feedback and additional testing would be greatly appreciated. Feel free to edit this PR if needed.